### PR TITLE
Shopware-Deployment: Increased version of webpack-cli from ^3.3.10 to…

### DIFF
--- a/packages/webpack-sw6-config/CHANGELOG.md
+++ b/packages/webpack-sw6-config/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 6.1.6
+- Increased version of `webpack-cli` from ^3.3.10 to ^4.4.0 to prevent endless 
+"Would you like to install webpack-cli?" request during deployment
+
+## 1.0.0
+- First release

--- a/packages/webpack-sw6-config/package.json
+++ b/packages/webpack-sw6-config/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@pixolith/webpack-sw6-config",
     "public": true,
-    "version": "6.1.5",
+    "version": "6.1.6",
     "description": "",
     "main": "src/index.js",
     "scripts": {},
@@ -83,7 +83,7 @@
         "time-fix-plugin": "^2.0.7",
         "url-loader": "^3.0.0",
         "webpack": "^4.41.5",
-        "webpack-cli": "^3.3.10",
+        "webpack-cli": "^4.4.0",
         "webpack-dev-server": "^3.10.1",
         "webpack-glob-entry": "^2.1.1",
         "webpack-merge": "^4.2.2",


### PR DESCRIPTION
… ^4.4.0 to prevent endless "Would you like to install webpack-cli?" request during deployment